### PR TITLE
Refactor controllers to return Response objects

### DIFF
--- a/app/Controllers/Admin/AdminAuthController.php
+++ b/app/Controllers/Admin/AdminAuthController.php
@@ -60,10 +60,10 @@ class AdminAuthController{
         
     }
 
-    public function logout(): void
+    public function logout(): Response
     {
         // In a real app, you might revoke the token or add to blacklist.
-        Response::success('Logged out successfully');
+        return Response::success('Logged out successfully');
     }
 
     /**
@@ -72,7 +72,7 @@ class AdminAuthController{
      * JWT must include {"sub": admin_id, "role": "admin"}.
      */
 
-     public function user(): void
+     public function user(): Response
     {
         // JWTMiddleware (see next section) will have validated the token
         // and put the admin’s ID into $_SERVER['admin_id'].
@@ -80,13 +80,11 @@ class AdminAuthController{
         $admin   = $this->adminModel->find($adminId);
 
         if (!$admin) {
-            Response::error('Admin not found in ctr', [], 404);
-            return;
+            return Response::error('Admin not found in ctr', [], 404);
         }
 
         // Omit password field
         unset($admin['password']);
-        Response::success('Admin profile', $admin);
-        return;
+        return Response::success('Admin profile', $admin);
     }
 }

--- a/app/Controllers/Admin/AdminOrderController.php
+++ b/app/Controllers/Admin/AdminOrderController.php
@@ -35,7 +35,7 @@ class AdminOrderController
      * GET /api/admin/orders
      * List all orders with optional filters (status_id, customer_id, date range).
      */
-    public function index(): void
+    public function index(): Response
     {
         // For MVP: return all orders
         $orders = $this->orderModel->all(); 
@@ -57,22 +57,20 @@ class AdminOrderController
 
 
         if(!$orders) {
-            Response::error('No orders found', [], 404);
-            return;
+            return Response::error('No orders found', [], 404);
         }
 
 
-        Response::success('All orders', [
+        return Response::success('All orders', [
             'orders' => $allOrders
         ], 200);
-        return;
     }
     
     /**
      * GET /api/admin/orders/{id}
      * View one order with line‐items.
      */
-    public function show(int $orderId): void
+    public function show(int $orderId): Response
     {
         $order = $this->orderModel->getOrderWithFoodItems($orderId);
         unset($order['customer_id']);
@@ -80,14 +78,12 @@ class AdminOrderController
         unset($order['status_key']);
         unset($order['status_label']);
         if (!$order) {
-            Response::error('Order not found', [], 404);
-            return;
+            return Response::error('Order not found', [], 404);
         }
 
    
 
-        Response::success('Order', ['order' => $order], 200);
-        return;
+        return Response::success('Order', ['order' => $order], 200);
     }
 
     /**
@@ -95,38 +91,33 @@ class AdminOrderController
      * Body: { "status_key": "confirmed" }  (key must exist in order_statuses)
     */
 
-    public function updateStatus(int $orderId): void
+    public function updateStatus(int $orderId): Response
     {
         $order = $this->orderModel->find($orderId);
         if (!$order) {
-            Response::error('Order not found', [], 404);
-            return;
+            return Response::error('Order not found', [], 404);
         }
 
         $body = $this->request->all();
         $newKey = $body['status_key'] ?? '';
         if (!$newKey) {
-            Response::error('status_key is required', [], 422);
-            return;
+            return Response::error('status_key is required', [], 422);
         }
     
         // 1) Find new status_id by key
         $newStatus = $this->statusModel->findByKey($newKey);
         if (!$newStatus) {
-           Response::error('Invalid status key', [], 422);
-           return;
+           return Response::error('Invalid status key', [], 422);
         }
 
         // 2) Update order status
         $result = $this->orderModel->updateStatus($orderId, $newStatus['id']);
 
         if(!$result){
-            Response::error('Failed to update order status', [], 500);
-            return;
+            return Response::error('Failed to update order status', [], 500);
         }
 
-        Response::success("Order status updated", [], 200);
-        return;
+        return Response::success("Order status updated", [], 200);
     }
         
 }

--- a/app/Controllers/Admin/AdminPaymentController.php
+++ b/app/Controllers/Admin/AdminPaymentController.php
@@ -20,24 +20,22 @@ class AdminPaymentController{
      * GET /api/admin/payments
      * List all payments
      */
-    public function index(): void
+    public function index(): Response
     {
         $payments = $this->paymentModel->all();
-        Response::success('All payments', $payments);
+        return Response::success('All payments', $payments);
     }
 
     /**
      * GET /api/admin/payments/{id}
      * View a single payment by ID
      */
-    public function show(int $id): void
+    public function show(int $id): Response
     {
         $payment = $this->paymentModel->find($id);
         if (!$payment) {
-            Response::error('Payment not found', [], 404);
-            return;
+            return Response::error('Payment not found', [], 404);
         }
-        Response::success('Payment details', $payment);
-        return;
+        return Response::success('Payment details', $payment);
     }
 }

--- a/app/Controllers/Admin/AdminSettingsController.php
+++ b/app/Controllers/Admin/AdminSettingsController.php
@@ -20,10 +20,10 @@ class AdminSettingsController
      * GET /api/admin/order-statuses
      * List all statuses
      */
-    public function allStatuses(): void
+    public function allStatuses(): Response
     {
         $statuses = $this->statusModel->all();
-        Response::success('All order statuses', $statuses);
+        return Response::success('All order statuses', $statuses);
     }
 
     
@@ -31,28 +31,25 @@ class AdminSettingsController
      * POST /api/admin/order-statuses
      * Body: { "key":"archived", "label":"Archived" }
      */
-    public function createStatus(): void
+    public function createStatus(): Response
     {
         $body = $this->request->all();
         $key   = $body['key']   ?? '';
         $label = $body['label'] ?? '';
         if (!$key || !$label) {
-            Response::error('Both key and label are required', [], 422);
-            return;
+            return Response::error('Both key and label are required', [], 422);
         }
         // 1) Check uniqueness
         if ($this->statusModel->findByKey($key)) {
-            Response::error('Status key already exists', [], 409);
-            return;
+            return Response::error('Status key already exists', [], 409);
         }
         // 2) Insert
         $result = $this->statusModel->create($key, $label);
         if (!$result) {
-            Response::error('Failed to create status', [], 500);
-            return;
+            return Response::error('Failed to create status', [], 500);
         } 
 
-        Response::success('Status created', [$result], 201);
+        return Response::success('Status created', [$result], 201);
     }
 
     /**
@@ -60,51 +57,44 @@ class AdminSettingsController
      *   - GET   /settings/{key} → fetch one status
      *   - PUT   /settings/{key} → update label
      */
-    public function getStatus(string $key): void
+    public function getStatus(string $key): Response
     {
         $status = $this->statusModel->findByKey($key);
         if (!$status) {
-            Response::error('Status not found', [], 404);
-            return;
+            return Response::error('Status not found', [], 404);
         }
-        Response::success('Status detail', $status);
+        return Response::success('Status detail', $status);
     }
 
-    public function updateStatus(string $key): void
+    public function updateStatus(string $key): Response
     {
         $body = $this->request->all();
         $label = $body['label'] ?? '';
         if (!$label) {
-            Response::error('Label is required', [], 422);
-            return;
+            return Response::error('Label is required', [], 422);
         }
         $status = $this->statusModel->findByKey($key);
         if (!$status) {
-            Response::error('Status not found', [], 404);
-            return;
+            return Response::error('Status not found', [], 404);
         }
         $result = $this->statusModel->update($status['id'], $label);
         if (!$result) {
-            Response::error('Failed to update', [], 500);
-            return;
-        } 
-        
-        Response::success('Status updated');
+            return Response::error('Failed to update', [], 500);
+        }
+
+        return Response::success('Status updated');
     }
 
-    public function deleteStatus(string $key): void
+    public function deleteStatus(string $key): Response
     {
         $status = $this->statusModel->findByKey($key);
         if (!$status) {
-            Response::error('Status not found', [], 404);
-            return;
+            return Response::error('Status not found', [], 404);
         }
         $result = $this->statusModel->delete($status['id']);
         if (!$result) {
-            Response::error('Failed to delete', [], 500);
-            return;
-        } 
-
-        Response::success('Status deleted');
+            return Response::error('Failed to delete', [], 500);
+        }
+        return Response::success('Status deleted');
     }
 }

--- a/app/Controllers/Customer/CustomerAuthController.php
+++ b/app/Controllers/Customer/CustomerAuthController.php
@@ -28,7 +28,7 @@ class CustomerAuthController{
      * POST /api/auth/register
      * { "email": "...", "password": "...", "name": "..." }
      */
-    public function register(): void
+    public function register(): Response
     {
         $body = $this->request->all();
 
@@ -39,17 +39,14 @@ class CustomerAuthController{
 
         // Basic validation for required fields
         if (!$this->validationEmail($email)) {
-            Response::error('Valid email required', [], 422);
-            return;
+            return Response::error('Valid email required', [], 422);
         }
         if (!$password || !$name) {
-            Response::error('Name and password are required', [], 422);
-            return;
+            return Response::error('Name and password are required', [], 422);
         }
 
         if ($this->customerModel->findByEmail($email)) {
-            Response::error('Email already exists', [], 409);
-            return;
+            return Response::error('Email already exists', [], 409);
         }
 
         // Only pass required fields to create
@@ -61,7 +58,7 @@ class CustomerAuthController{
 
         $token = JWTService::generateToken($customerId, 'customer');
 
-        Response::success('Registration successful', [
+        return Response::success('Registration successful', [
             'token'   => $token,
             'user_id' => $customerId
         ], 201);
@@ -70,7 +67,7 @@ class CustomerAuthController{
      * POST /api/auth/login
      * { "email": "...", "password": "..." }
      */
-    public function login(): void
+    public function login(): Response
     {
         $body = $this->request->all();
         $email = $body['email'] ?? '';
@@ -82,13 +79,11 @@ class CustomerAuthController{
 
         // Basic validation
         if (!$this->validationEmail($email)) {
-            Response::error('Valid email required', [], 422);
-            return;
+            return Response::error('Valid email required', [], 422);
         }
 
         if (strlen($password) < 6) {
-            Response::error('Password must be at least 6 characters', [], 422);
-            return;
+            return Response::error('Password must be at least 6 characters', [], 422);
         }
 
         // Find user by email
@@ -97,8 +92,7 @@ class CustomerAuthController{
         // Debug: Check if user was found (remove in production)
         if (!$user) {
             error_log("User not found for email: " . $email);
-            Response::error('Invalid credentials email', [], 401);
-            return;
+            return Response::error('Invalid credentials email', [], 401);
         }
 
         // Debug: Log password verification (remove in production)
@@ -109,44 +103,42 @@ class CustomerAuthController{
         // Verify password
         if (!$passwordMatch) {
             error_log("Password mismatch for email: " . $email);
-            Response::error('Invalid credentials', [], 401);
-            return;
+            return Response::error('Invalid credentials', [], 401);
         }
 
         // Generate token
         $token = JWTService::generateToken($user['id'], 'customer');
 
         // Success response
-        Response::success('Login successful', [
+        return Response::success('Login successful', [
             'token' => $token,
             'user_id' => $user['id']
         ]);
     }
 
      /** POST /api/auth/logout */
-    public function logout(): void
+    public function logout(): Response
     {
         // Token revocation / blacklist could live here
-        Response::success('Logged out successfully');
+        return Response::success('Logged out successfully');
     }
 
 
     /** GET /api/auth/profile (auth:customer) */
-    public function profile(): void
+    public function profile(): Response
     {
         $customerId = (int) ($_SERVER['user_id'] ?? 0);
         $user   = $this->customerModel->find($customerId);
 
         if (!$user) {
-            Response::error('Customer not found', [], 404);
-            return;
+            return Response::error('Customer not found', [], 404);
         }
         unset($user['password']);
-        Response::success('Customer profile', $user);
+        return Response::success('Customer profile', $user);
     }
 
      /** PUT /api/auth/profile (auth:customer) */
-    public function updateProfile(): void
+    public function updateProfile(): Response
     {
         $customerId = (int) ($_SERVER['user_id'] ?? 0);
         $body   = $this->request->all();
@@ -154,29 +146,26 @@ class CustomerAuthController{
         // Allow name / phone / address; ignore others
         $allowed = array_intersect_key($body, array_flip(['name', 'phone', 'address']));
         if (empty($allowed)) {
-            Response::error('Nothing to update', [], 422);
-            return;
+            return Response::error('Nothing to update', [], 422);
         }
 
         $updated = $this->customerModel->update($customerId, $allowed);
-        Response::success('Profile updated', ['Customer' => $updated], 201);
+        return Response::success('Profile updated', ['Customer' => $updated], 201);
     }
 
-    public function updateCustomerProfilePicture(): void{
+    public function updateCustomerProfilePicture(): Response{
         $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
         $customerId = $_SERVER['user_id'] ?? '';
         if (strpos($contentType, 'multipart/form-data') !== false) {
             $body = $_POST;
         } else {
-            Response::error('Only accept form data', [], 400);
-            return;
+            return Response::error('Only accept form data', [], 400);
         }
         
          // Check if customer exists
         $customer = $this->customerModel->find($customerId);
         if (!$customer) {
-            Response::error('Customer not found', [], 404);
-            return;
+            return Response::error('Customer not found', [], 404);
         }
 
         // Check for image file
@@ -196,20 +185,17 @@ class CustomerAuthController{
                 $result = $this->customerModel->imageUpdate($customerId, ['image' => $photoUrl]);
             
             } else {
-                Response::error("Image upload to Cloudinary failed", [], 500);
-                return;
+                return Response::error("Image upload to Cloudinary failed", [], 500);
             }
         } else {
-            Response::error("No valid image file provided", [], 400);
-            return;
+            return Response::error("No valid image file provided", [], 400);
         }
 
         if (!$result) {
-            Response::error("Image upload failed", ["result" => $result], 500);
-            return;
+            return Response::error("Image upload failed", ["result" => $result], 500);
         }
 
-        Response::success("Image upload success", [], 200);
+        return Response::success("Image upload success", [], 200);
 
     }
 

--- a/app/Controllers/Customer/CustomerOrderController.php
+++ b/app/Controllers/Customer/CustomerOrderController.php
@@ -29,7 +29,7 @@ class CustomerOrderController
     }
 
     /** POST /orders */
-    public function store(): void
+    public function store(): Response
     {
         $body = $this->request->all();
 
@@ -38,24 +38,22 @@ class CustomerOrderController
         $customerId = (int) ($_SERVER['user_id'] ?? 0);
 
         if (empty($body['items']) || !is_array($body['items'])) {
-            Response::error('Items are required and must be an array', [], 422);
-            return;
+            return Response::error('Items are required and must be an array', [], 422);
         }
 
         $order = $this->orderModel->createWithInventory($customerId, $items, $remarks ?? null);
-        Response::success('Order created', ['orders' => $order], 201);
+        return Response::success('Order created', ['orders' => $order], 201);
     }
 
     /** GET /orders */
-    public function index(): void
+    public function index(): Response
     {
         $customerId = (int) ($_SERVER['user_id'] ?? 0);
         $orders = $this->orderModel->getOrderHistory($customerId);
 
         $customer = $this->customerModel->find($customerId);
         if (!$customer) {
-            Response::error('Customer not found', [], 404);
-            return;
+            return Response::error('Customer not found', [], 404);
         }
         unset($customer['password']);
         unset($customer['created_at']);
@@ -64,7 +62,7 @@ class CustomerOrderController
       
 
         if (!$orders) {
-            Response::error('No orders found', [], 404);
+            return Response::error('No orders found', [], 404);
         }
         
         $allOrders = [];
@@ -87,23 +85,22 @@ class CustomerOrderController
             $allOrders[] = $order;
         }
 
-        Response::success('Orders retrieved', 
+        return Response::success('Orders retrieved',
                 [
-                    'customer' => $customer, 
+                    'customer' => $customer,
                     'orders' => $allOrders
-                ], 
+                ],
             200);
     }
 
     /** GET /orders/{id} */
-    public function show(int $id): void
+    public function show(int $id): Response
     {
         $customerId = (int) ($_SERVER['user_id'] ?? 0);
 
         $order = $this->orderModel->findOrderForCustomer($id, $customerId);
         if (!$order) {
-            Response::error('Order not found', [], 404);
-            return;
+            return Response::error('Order not found', [], 404);
         }
 
         $food_detail = $this->foodOrderModel->getFoodDetailByOrderId($id);
@@ -124,19 +121,18 @@ class CustomerOrderController
         
        
 
-        Response::success('Order retrieved', ['order' => $order]);
+        return Response::success('Order retrieved', ['order' => $order]);
     }
 
     /** DELETE /orders/{id} */
-    public function cancel(int $id): void
+    public function cancel(int $id): Response
     {
         $customerId = (int) ($_SERVER['user_id'] ?? 0);
         
         $order = $this->orderModel->cancelIfPending($id, $customerId);
         if (!$order) {
-            Response::error('Cannot cancel order', ['cancelled order' => $order], 422);
-            return;
+            return Response::error('Cannot cancel order', ['cancelled order' => $order], 422);
         }
-        Response::success('Order cancelled', $order);
+        return Response::success('Order cancelled', $order);
     }
 }

--- a/app/Controllers/public/MenuController.php
+++ b/app/Controllers/public/MenuController.php
@@ -17,7 +17,7 @@ class MenuController
     }
 
     /** GET /menu */
-    public function index(): void
+    public function index(): Response
     {
         $filters = [];
         
@@ -30,17 +30,16 @@ class MenuController
         }
 
         $foods = $this->foodModel->all($filters);
-        Response::success('Foods retrieved successfully', ['foods' => $foods]);
+        return Response::success('Foods retrieved successfully', ['foods' => $foods]);
     }
 
     /** GET /menu/{id} */
-    public function show(int $id): void
+    public function show(int $id): Response
     {
         $food = $this->foodModel->find($id);
         if (!$food) {
-            Response::error('Food not found', [], 404);
-            return;
+            return Response::error('Food not found', [], 404);
         }
-        Response::success('Food retrieved successfully', $food);
+        return Response::success('Food retrieved successfully', $food);
     }
 }

--- a/app/Controllers/public/PublicController.php
+++ b/app/Controllers/public/PublicController.php
@@ -23,7 +23,7 @@ class PublicController
      * GET /api/public/vendors
      * Fetch all vendors for main application listing
      */
-    public function getAllVendors(): void
+    public function getAllVendors(): Response
     {
         $vendors = $this->vendorModel->all();
         
@@ -39,19 +39,18 @@ class PublicController
         }
         unset($vendor); // break reference
         
-        Response::success('All vendors retrieved',['vendors' => $vendors]);
+        return Response::success('All vendors retrieved',['vendors' => $vendors]);
     }
 
     /**
      * GET /api/public/foods
      * Fetch all foods for main application listing
      */
-    public function getAllFoods(): void
+    public function getAllFoods(): Response
     {
         $foods = $this->foodModel->all();
         if(!$foods) {
-            Response::error('No foods found', [], 404);
-            return;
+            return Response::error('No foods found', [], 404);
         }
 
 
@@ -68,20 +67,19 @@ class PublicController
      
         }
 
-        Response::success('All foods retrieved', ['foods' => $foods]);
+        return Response::success('All foods retrieved', ['foods' => $foods]);
     }
 
     /**
      * GET /api/public/vendors/{id}
      * Fetch vendor details with their food list
      */
-    public function getVendorDetails(int $vendorId): void
+    public function getVendorDetails(int $vendorId): Response
     {
         // Get vendor details
         $vendor = $this->vendorModel->find($vendorId);
         if (!$vendor) {
-            Response::error('Vendor not found', [], 404);
-            return;
+            return Response::error('Vendor not found', [], 404);
         }
 
         // Remove sensitive information
@@ -101,19 +99,18 @@ class PublicController
             'foods' => $foods
         ];
 
-        Response::success('Vendor details with foods', $vendorWithFoods);
+        return Response::success('Vendor details with foods', $vendorWithFoods);
     }
 
     /**
      * GET /api/public/foods/{id}
      * Fetch specific food details
      */
-    public function getFoodDetails(int $foodId): void
+    public function getFoodDetails(int $foodId): Response
     {
         $food = $this->foodModel->find($foodId);
         if (!$food) {
-            Response::error('Food not found', [], 404);
-            return;
+            return Response::error('Food not found', [], 404);
         }
     
         $vendorId = $food["vendor_id"];
@@ -125,6 +122,6 @@ class PublicController
         
         $food['vendor'] = $vendor;
 
-        Response::success('Food details', $food);
+        return Response::success('Food details', $food);
     }
 }

--- a/app/Core/ErrorHandler.php
+++ b/app/Core/ErrorHandler.php
@@ -6,17 +6,17 @@ use App\Core\Response;
 use Throwable;
 
 class ErrorHandler {
-    public static function handleException(Throwable $e): Response{
+    public static function handleException(Throwable $e): void{
         http_response_code(500);
 
         if($_ENV['APP_ENV'] === "development"){
 
-            $response = Response::success($e->getMessage(), 
-            ["line"=> $e->getLine(), 'file' => $e->getFile(), 'code' => $e->getCode(), 'stackTrace' => $e->getTrace()], 500);
+            Response::success($e->getMessage(),
+            ["line"=> $e->getLine(), 'file' => $e->getFile(), 'code' => $e->getCode(), 'stackTrace' => $e->getTrace()], 500)->json();
         }else{ 
             //for the user to see;
             echo "Something went wrong, please try again later";
         }    
-        return $response->json();
+        return;
     }
 }

--- a/public/db-health.php
+++ b/public/db-health.php
@@ -26,11 +26,11 @@ try {
         'is_connected' => $stats['is_connected'],
         'test_query_result' => $result['test'],
         'timestamp' => date('Y-m-d H:i:s')
-    ]);
+    ])->json();
     
 } catch (Exception $e) {
     Response::error('Database health check failed', [
         'error' => $e->getMessage(),
         'timestamp' => date('Y-m-d H:i:s')
-    ], 500);
+    ], 500)->json();
 }


### PR DESCRIPTION
## Summary
- return `Response` objects from controllers
- update health check script for new `Response` API
- adjust `ErrorHandler` to output JSON directly

## Testing
- `composer install`
- `composer dump-autoload`
- `php vendor/phpunit/phpunit/phpunit tests` *(fails: Login should return 200)*

------
https://chatgpt.com/codex/tasks/task_e_688acebb62b083278f90141947c3415d