### PR TITLE
Fix dynamic param routing

### DIFF
--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -47,8 +47,10 @@ class Router{
         
         // Check for dynamic routes
         foreach ($this->routes[$method] ?? [] as $pattern => $route) {
-            // Convert {id} to regex pattern
-            $regex = preg_replace('/\{([^}]+)\}/', '(\d+)', $pattern);
+            // Convert {param} placeholders to a generic regex pattern that
+            // captures any URI segment except a slash. This allows IDs or
+            // slugs (e.g. `/api/v1/food/1` or `/api/v1/vendor/abc-123`).
+            $regex = preg_replace('/\{([^}]+)\}/', '([^/]+)', $pattern);
             $regex = '#^' . $regex . '$#';
             
             if (preg_match($regex, $uri, $matches)) {


### PR DESCRIPTION
## Summary
- improve regex handling for dynamic parameters in Router to support slugs

## Testing
- `composer install`
- `composer dump-autoload`
- `php vendor/bin/phpunit --stop-on-failure` *(fails: Login should return 200)*

------
https://chatgpt.com/codex/tasks/task_e_688b1437737c832791140d2a2b951551