### PR TITLE
Fix middleware response chain

### DIFF
--- a/app/Middleware/CacheMiddleware.php
+++ b/app/Middleware/CacheMiddleware.php
@@ -15,11 +15,11 @@ class CacheMiddleware
        
     }
 
-    public function __invoke(Request $req, callable $next): void
+    public function __invoke(Request $req, callable $next): Response
     {
         error_log("CacheMiddleware invoked for: " . $req->path());
         $this->req = $req; // Store the request for later use
-        $this->handle($req, $next);
+        return $this->handle($req, $next);
     }
 
     public function handle(Request $req, callable $next): Response

--- a/app/Middleware/JWTMiddleware.php
+++ b/app/Middleware/JWTMiddleware.php
@@ -19,14 +19,14 @@ class JWTMiddleware{
         $this->req = $req;
     }
 
-    public function __invoke(Request $req, callable $next): void
+    public function __invoke(Request $req, callable $next): Response
     {
         error_log("JWTMiddleware invoked");
         //This is the entry point for the middleware
         $this->req = $req; // Store the request for later use
-        $this->handle($req, $next);
+        return $this->handle($req, $next);
         //Call the next middleware or controller
-      
+
     }
     
     public function handle(Request $req, callable $next):Response {


### PR DESCRIPTION
## Summary
- update `CacheMiddleware` and `JWTMiddleware` to return responses
- rework `Router` to run middleware chain including the controller

## Testing
- `composer install`
- `composer dump-autoload`
- `php vendor/bin/phpunit --stop-on-failure` *(fails: Login should return 200)*

------
https://chatgpt.com/codex/tasks/task_e_688c313bf0cc83279558d083fa2f2a1f