### PR TITLE
Add PHPUnit unit tests for controllers

### DIFF
--- a/tests/AdminControllerTest.php
+++ b/tests/AdminControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use App\Controllers\Admin\AdminAuthController;
+use App\Core\Response;
+use App\Core\JWTService;
+use App\Models\Admin;
+use App\Core\Request;
+
+class AdminControllerTest extends TestCase
+{
+    private function inject(object $obj, string $prop, $value): void
+    {
+        $ref = new \ReflectionClass($obj);
+        $property = $ref->getProperty($prop);
+        $property->setAccessible(true);
+        $property->setValue($obj, $value);
+    }
+
+    public function testLoginSuccessReturnsToken(): void
+    {
+        $_ENV['JWT_SECRET'] = 'testsecret';
+        JWTService::init();
+
+        $adminData = [
+            'id' => 1,
+            'email' => 'admin@example.com',
+            'password' => password_hash('pass', PASSWORD_DEFAULT)
+        ];
+        $adminModel = $this->getMockBuilder(Admin::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findByEmail'])
+            ->getMock();
+        $adminModel->expects($this->any())
+            ->method('findByEmail')
+            ->willReturn($adminData);
+
+        $requestStub = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['isJson','input'])
+            ->getMock();
+        $requestStub->expects($this->any())
+            ->method('isJson')
+            ->willReturn(true);
+        $requestStub->expects($this->any())
+            ->method('input')
+            ->willReturnCallback(function($key,$default=null){
+            return ['email'=>'admin@example.com','password'=>'pass'][$key] ?? $default;
+        });
+
+        $controller = (new \ReflectionClass(AdminAuthController::class))->newInstanceWithoutConstructor();
+        $this->inject($controller, 'adminModel', $adminModel);
+        $this->inject($controller, 'request', $requestStub);
+        $this->inject($controller, 'response', new Response());
+
+        $response = $controller->login();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(200, $response->status());
+        $body = $response->body();
+        $this->assertTrue($body['success']);
+        $this->assertArrayHasKey('token', $body['data']);
+    }
+
+    public function testUserProfileReturnsData(): void
+    {
+        $adminData = [
+            'id' => 1,
+            'email' => 'admin@example.com',
+            'password' => 'hash',
+            'name' => 'Admin'
+        ];
+        $adminModel = $this->getMockBuilder(Admin::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['find'])
+            ->getMock();
+        $adminModel->expects($this->any())
+            ->method('find')
+            ->willReturn($adminData);
+
+        $controller = (new \ReflectionClass(AdminAuthController::class))->newInstanceWithoutConstructor();
+        $this->inject($controller, 'adminModel', $adminModel);
+        $requestMock = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->inject($controller, 'request', $requestMock);
+
+        $_SERVER['user_id'] = 1;
+        $response = $controller->user();
+
+        $this->assertEquals(200, $response->status());
+        $this->assertTrue($response->body()['success']);
+        $this->assertEquals('Admin profile', $response->body()['message']);
+        $this->assertArrayNotHasKey('password', $response->body()['data']);
+    }
+}

--- a/tests/CustomerControllerTest.php
+++ b/tests/CustomerControllerTest.php
@@ -1,0 +1,101 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use App\Controllers\Customer\CustomerAuthController;
+use App\Core\Response;
+use App\Core\JWTService;
+use App\Models\Customer;
+use App\Core\Request;
+
+class CustomerControllerTest extends TestCase
+{
+    private function inject(object $obj, string $prop, $value): void
+    {
+        $ref = new \ReflectionClass($obj);
+        $property = $ref->getProperty($prop);
+        $property->setAccessible(true);
+        $property->setValue($obj, $value);
+    }
+
+    public function testRegisterCreatesCustomer(): void
+    {
+        $_ENV['JWT_SECRET'] = 'secret';
+        JWTService::init();
+
+        $customerModel = $this->getMockBuilder(Customer::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findByEmail','create'])
+            ->getMock();
+        $customerModel->expects($this->any())
+            ->method('findByEmail')
+            ->willReturn(null);
+        $customerModel->expects($this->any())
+            ->method('create')
+            ->willReturn(2);
+
+        $requestStub = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['all'])
+            ->getMock();
+        $requestStub->expects($this->any())
+            ->method('all')
+            ->willReturn([
+            'email' => 'user@example.com',
+            'password' => 'secret1',
+            'name' => 'John'
+        ]);
+
+        $controller = (new \ReflectionClass(CustomerAuthController::class))->newInstanceWithoutConstructor();
+        $this->inject($controller, 'customerModel', $customerModel);
+        $this->inject($controller, 'request', $requestStub);
+
+        $response = $controller->register();
+
+        $this->assertEquals(201, $response->status());
+        $body = $response->body();
+        $this->assertTrue($body['success']);
+        $this->assertEquals(2, $body['data']['user_id']);
+        $this->assertArrayHasKey('token', $body['data']);
+    }
+
+    public function testLoginSucceedsWithValidCredentials(): void
+    {
+        $_ENV['JWT_SECRET'] = 'secret';
+        JWTService::init();
+
+        $hashed = password_hash('mypassword', PASSWORD_DEFAULT);
+        $customerModel = $this->getMockBuilder(Customer::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findByEmail'])
+            ->getMock();
+        $customerModel->expects($this->any())
+            ->method('findByEmail')
+            ->willReturn([
+            'id' => 5,
+            'email' => 'me@example.com',
+            'password' => $hashed
+        ]);
+
+        $requestStub = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['all'])
+            ->getMock();
+        $requestStub->expects($this->any())
+            ->method('all')
+            ->willReturn([
+            'email' => 'me@example.com',
+            'password' => 'mypassword'
+        ]);
+
+        $controller = (new \ReflectionClass(CustomerAuthController::class))->newInstanceWithoutConstructor();
+        $this->inject($controller, 'customerModel', $customerModel);
+        $this->inject($controller, 'request', $requestStub);
+
+        $response = $controller->login();
+
+        $this->assertEquals(200, $response->status());
+        $this->assertTrue($response->body()['success']);
+        $this->assertArrayHasKey('token', $response->body()['data']);
+    }
+}

--- a/tests/PublicControllerTest.php
+++ b/tests/PublicControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/../app/Controllers/public/PublicController.php';
+use App\Controllers\Public\PublicController;
+use App\Models\Vendor;
+use App\Models\Food;
+use App\Core\Response;
+
+class PublicControllerTest extends TestCase
+{
+    private function inject(object $obj, string $prop, $value): void
+    {
+        $ref = new \ReflectionClass($obj);
+        $property = $ref->getProperty($prop);
+        $property->setAccessible(true);
+        $property->setValue($obj, $value);
+    }
+
+    public function testGetAllVendorsReturnsSanitizedData(): void
+    {
+        $vendors = [
+            [
+                'id' => 1,
+                'email' => 'v@example.com',
+                'password' => 'hash',
+                'name' => 'Vendor',
+                'food_types' => '[]'
+            ]
+        ];
+        $foods = [
+            [
+                'id' => 5,
+                'vendor_id' => 1,
+                'name' => 'Pizza',
+                'created_at' => '',
+                'updated_at' => ''
+            ]
+        ];
+
+        $vendorModel = $this->getMockBuilder(Vendor::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['all'])
+            ->getMock();
+        $vendorModel->expects($this->any())
+            ->method('all')
+            ->willReturn($vendors);
+
+        $foodModel = $this->getMockBuilder(Food::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['allByVendor'])
+            ->getMock();
+        $foodModel->expects($this->any())
+            ->method('allByVendor')
+            ->willReturn($foods);
+
+        $controller = (new \ReflectionClass(PublicController::class))->newInstanceWithoutConstructor();
+        $this->inject($controller, 'vendorModel', $vendorModel);
+        $this->inject($controller, 'foodModel', $foodModel);
+
+        $response = $controller->getAllVendors();
+
+        $this->assertEquals(200, $response->status());
+        $body = $response->body();
+        $this->assertTrue($body['success']);
+        $vendor = $body['data']['vendors'][0];
+        $this->assertArrayNotHasKey('email', $vendor);
+        $this->assertArrayNotHasKey('password', $vendor);
+        $this->assertArrayHasKey('foods', $vendor);
+        $this->assertArrayNotHasKey('vendor_id', $vendor['foods'][0]);
+    }
+}


### PR DESCRIPTION
## Summary
- add new unit tests covering AdminAuthController, CustomerAuthController, and PublicController
- use reflection and PHPUnit mocks to inject dependencies
- demonstrate basic behaviour for login, profile, registration, and vendor listing

## Testing
- `composer dump-autoload`
- `php vendor/bin/phpunit -d memory_limit=512M` *(fails: Tests\ApiTest::testFullJwtProtectedWorkflow)*

------
https://chatgpt.com/codex/tasks/task_e_688c9cb8f81883279cef82fe36affd36